### PR TITLE
Coordinator-worker handshake functionality (closes #27)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -g -pthread
+CFLAGS = -Wall -Wextra -g -pthread -Icommon
 
 all: coordinatorMake workerMake
 
 coordinatorMake: coordinator/coordinator.c
-	$(CC) $(CFLAGS) -o coordinator_app coordinator/coordinator.c -lcjson
+	$(CC) $(CFLAGS) -o coordinator_app coordinator/coordinator.c common/common.c -lcjson
 
 workerMake: worker/worker.c
-	$(CC) $(CFLAGS) -o worker_app worker/worker.c -lcjson
+	$(CC) $(CFLAGS) -o worker_app worker/worker.c common/common.c -lcjson
 
 clean:
 	rm -f coordinator_app worker_app

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ A remote compiler that seeks to reduce program compilation time by coordinating 
    - The amount of time it would take for the node to transfer a file
    - How many jobs are already queued and their expected completion times
    - A reliability metric
-3) When joining the compilation network, nodes engage in a handshake with the coordinator to ensure that they’re capable of compiling the file in such a way that it could be integrated within the larger solution. During this handshake process, the compiler confirmes:
-    - Architecture
-    - Compiler version
+3) When joining the compilation network, nodes engage in a handshake with the coordinator to ensure that they’re capable of compiling the file in such a way that it could be integrated within the larger solution. During this handshake process, the compiler confirms:
+   - Architecture
+   - Compiler version
+   - Operating system
+   - RPC protocol version
 4) The remote compiler has a command-line interface and uses remote procedure calls to conduct jobs such as:
    - File discovery
    - Compilation

--- a/common/common.c
+++ b/common/common.c
@@ -1,0 +1,27 @@
+#include "common.h"
+
+const char *remocom_detect_target_arch(void) {
+#if defined(__x86_64__) || defined(_M_X64)
+    return "x86_64";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    return "aarch64";
+#elif defined(__arm__) || defined(_M_ARM)
+    return "arm";
+#elif defined(__i386__) || defined(_M_IX86)
+    return "x86";
+#else
+    return "unknown";
+#endif
+}
+
+const char *remocom_detect_target_os(void) {
+#if defined(__linux__)
+    return "linux";
+#elif defined(__APPLE__) && defined(__MACH__)
+    return "macos";
+#elif defined(_WIN32)
+    return "windows";
+#else
+    return "unknown";
+#endif
+}

--- a/common/common.h
+++ b/common/common.h
@@ -1,0 +1,20 @@
+// Shared RPC protocol and handshake field definitions.
+#ifndef REMOCOM_COMMON_H
+#define REMOCOM_COMMON_H
+
+#define REMOCOM_RPC_PROTOCOL_VERSION 1
+
+#define MSG_TYPE_HANDSHAKE "handshake"
+#define MSG_TYPE_HANDSHAKE_ACK "handshake_ack"
+#define MSG_TYPE_HANDSHAKE_REJECT "handshake_reject"
+#define MSG_TYPE_HANDSHAKE_REQUIRED "handshake_required"
+
+#define HANDSHAKE_KEY_GCC_VERSION "gcc_version"
+#define HANDSHAKE_KEY_TARGET_ARCH "target_arch"
+#define HANDSHAKE_KEY_TARGET_OS "target_os"
+#define HANDSHAKE_KEY_RPC_PROTOCOL_VERSION "rpc_protocol_version"
+
+const char *remocom_detect_target_arch(void);
+const char *remocom_detect_target_os(void);
+
+#endif

--- a/coordinator/coordinator.c
+++ b/coordinator/coordinator.c
@@ -7,6 +7,7 @@
 #include <cjson/cJSON.h> // Ultra lightweight JSON parser library
 #include <time.h>
 #include <stdarg.h>
+#include "../common/common.h"
 
 #define PORT 5000
 #define BUFFER_SIZE 1024
@@ -23,6 +24,7 @@ typedef struct {
     char ip_address[INET_ADDRSTRLEN];
     time_t last_heartbeat; // timestamp
     NodeStatus status; // alive or dead
+    int handshake_completed;
 } Node;
 
 Node workers[MAX_WORKERS];
@@ -44,6 +46,60 @@ pthread_mutex_t task_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void send_json_message(int client_fd, const char *type_str, const char *payload_str);
 void *handle_worker(void *arg);
+
+/// @brief Validates and applies handshake payload for a worker.
+/// @param worker Worker record to update if handshake is accepted.
+/// @param payload Parsed payload object from incoming message.
+/// @param reason_buf Output buffer for mismatch reason.
+/// @param reason_buf_len Size of reason buffer.
+/// @return 1 if payload matches coordinator requirements, 0 otherwise.
+static int validate_handshake_payload(Node *worker, cJSON *payload, char *reason_buf, size_t reason_buf_len) {
+    if (payload == NULL || !cJSON_IsObject(payload)) {
+        snprintf(reason_buf, reason_buf_len, "Handshake payload must be an object");
+        return 0;
+    }
+
+    cJSON *gcc_version = cJSON_GetObjectItem(payload, HANDSHAKE_KEY_GCC_VERSION);
+    cJSON *target_arch = cJSON_GetObjectItem(payload, HANDSHAKE_KEY_TARGET_ARCH);
+    cJSON *target_os = cJSON_GetObjectItem(payload, HANDSHAKE_KEY_TARGET_OS);
+    cJSON *rpc_protocol_version = cJSON_GetObjectItem(payload, HANDSHAKE_KEY_RPC_PROTOCOL_VERSION);
+
+    if (!cJSON_IsString(gcc_version) || !cJSON_IsString(target_arch) ||
+        !cJSON_IsString(target_os) || !cJSON_IsNumber(rpc_protocol_version)) {
+        snprintf(reason_buf, reason_buf_len, "Handshake payload missing required fields");
+        return 0;
+    }
+
+    if (strcmp(gcc_version->valuestring, __VERSION__) != 0) {
+        snprintf(reason_buf, reason_buf_len, "GCC mismatch worker=%s coordinator=%s",
+            gcc_version->valuestring, __VERSION__);
+        return 0;
+    }
+
+    const char *expected_arch = remocom_detect_target_arch();
+    if (strcmp(target_arch->valuestring, expected_arch) != 0) {
+        snprintf(reason_buf, reason_buf_len, "Architecture mismatch worker=%s coordinator=%s",
+            target_arch->valuestring, expected_arch);
+        return 0;
+    }
+
+    const char *expected_os = remocom_detect_target_os();
+    if (strcmp(target_os->valuestring, expected_os) != 0) {
+        snprintf(reason_buf, reason_buf_len, "OS mismatch worker=%s coordinator=%s",
+            target_os->valuestring, expected_os);
+        return 0;
+    }
+
+    int worker_protocol_version = rpc_protocol_version->valueint;
+    if (worker_protocol_version != REMOCOM_RPC_PROTOCOL_VERSION) {
+        snprintf(reason_buf, reason_buf_len, "RPC protocol version mismatch worker=%d coordinator=%d",
+            worker_protocol_version, REMOCOM_RPC_PROTOCOL_VERSION);
+        return 0;
+    }
+
+    worker->handshake_completed = 1;
+    return 1;
+}
 
 /// @brief Thread-safe logging helper for coordinator events.
 /// @param format printf-style format string.
@@ -111,6 +167,7 @@ static void dispatch_worker_message(int client_fd, cJSON *type, cJSON *payload, 
 
     int node_id = worker->nodeID;
     NodeStatus status = worker->status;
+    int handshake_completed = worker->handshake_completed;
 
     if (status == dead) {
         pthread_mutex_unlock(&workers_mutex);
@@ -124,9 +181,39 @@ static void dispatch_worker_message(int client_fd, cJSON *type, cJSON *payload, 
         return;
     }
 
-    printf("Received Type: %s | Payload: %s \n", type->valuestring, payload->valuestring);
+    char *payload_str = cJSON_PrintUnformatted(payload);
+    if (payload_str == NULL) {
+        payload_str = strdup("<unprintable>");
+    }
+
+    printf("Received Type: %s | Payload: %s \n", type->valuestring, payload_str);
     log_event("MESSAGE RECEIVED by Node %d | Type: %s | Payload: %s\n",
-        node_id, type->valuestring, payload->valuestring);
+        node_id, type->valuestring, payload_str);
+
+    free(payload_str);
+
+    if (strcmp(type->valuestring, MSG_TYPE_HANDSHAKE) == 0) {
+        char mismatch_reason[256];
+        int handshake_ok = validate_handshake_payload(worker, payload, mismatch_reason, sizeof(mismatch_reason));
+        pthread_mutex_unlock(&workers_mutex);
+
+        if (handshake_ok) {
+            send_json_message(client_fd, MSG_TYPE_HANDSHAKE_ACK, "Handshake accepted");
+            log_event("HANDSHAKE ACCEPTED Node %d\n", node_id);
+            return;
+        }
+
+        send_json_message(client_fd, MSG_TYPE_HANDSHAKE_REJECT, mismatch_reason);
+        log_event("HANDSHAKE REJECTED Node %d | Reason: %s\n", node_id, mismatch_reason);
+        *is_dead = 1;
+        return;
+    }
+
+    if (!handshake_completed) {
+        pthread_mutex_unlock(&workers_mutex);
+        send_json_message(client_fd, MSG_TYPE_HANDSHAKE_REQUIRED, "Handshake required before registration");
+        return;
+    }
 
     // Handle heartbeat immediately to keep worker alive in the system.
     if (strcmp(type->valuestring, "heartbeat") == 0) {
@@ -197,6 +284,7 @@ static int register_worker(int client_fd, const struct sockaddr_in *client_addr)
     worker->nodeID = worker_count;
     worker->last_heartbeat = time(NULL);
     worker->status = alive;
+    worker->handshake_completed = 0;
 
     // Convert the client's IP address to a string and store it in the worker struct.
     inet_ntop(AF_INET, &client_addr->sin_addr, worker->ip_address, INET_ADDRSTRLEN);
@@ -351,7 +439,7 @@ void *handle_worker(void *arg) {
         cJSON *payload = cJSON_GetObjectItem(msg, "payload");
 
         // Make sure message has the required fields in string form.
-        if (type == NULL || payload == NULL || !cJSON_IsString(type) || !cJSON_IsString(payload)) {
+        if (type == NULL || payload == NULL || !cJSON_IsString(type)) {
             printf("Missing fields in JSON\n");
             log_event("[WARNING] Missing fields in JSON message\n");
             cJSON_Delete(msg);

--- a/worker/worker.c
+++ b/worker/worker.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <cjson/cJSON.h>
+#include "../common/common.h"
 
 #define PORT 5000
 #define BUFFER_SIZE 1024
@@ -56,6 +57,28 @@ static void send_json_message(int sock_fd, const char *type, const char *payload
     free(json_string);   // frees memory created by cJSON_Print()
 }
 
+/// @brief Sends a handshake payload describing worker build/runtime compatibility.
+/// @param sock_fd The file descriptor for the coordinator socket.
+static void send_handshake_message(int sock_fd) {
+    cJSON *msg = cJSON_CreateObject();
+    cJSON *payload = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(msg, "type", MSG_TYPE_HANDSHAKE);
+    cJSON_AddItemToObject(msg, "payload", payload);
+
+    cJSON_AddStringToObject(payload, HANDSHAKE_KEY_GCC_VERSION, __VERSION__);
+    cJSON_AddStringToObject(payload, HANDSHAKE_KEY_TARGET_ARCH, remocom_detect_target_arch());
+    cJSON_AddStringToObject(payload, HANDSHAKE_KEY_TARGET_OS, remocom_detect_target_os());
+    cJSON_AddNumberToObject(payload, HANDSHAKE_KEY_RPC_PROTOCOL_VERSION, REMOCOM_RPC_PROTOCOL_VERSION);
+
+    // Convert JSON object into a string to be sent through the socket.
+    char *json_string = cJSON_PrintUnformatted(msg);
+    send(sock_fd, json_string, strlen(json_string), 0);
+
+    cJSON_Delete(msg);
+    free(json_string);
+}
+
 /// @brief Receives data from the coordinator into a buffer and stores it in the buffer.
 /// @param sock_fd The file descriptor for the coordinator socket.
 /// @param buffer The buffer to receive data into.
@@ -67,6 +90,58 @@ static int receive_into_buffer(int sock_fd, char *buffer) {
         buffer[bytes] = '\0'; // add string ending character so C prints safely
     }
     return bytes;
+}
+
+/// @brief Parses coordinator response type field into output buffer.
+/// @param json_input Raw JSON response from coordinator.
+/// @param out_type Destination buffer for "type" field.
+/// @param out_type_size Destination buffer size.
+/// @return 1 when parse succeeds and type is present, 0 otherwise.
+static int parse_response_type(const char *json_input, char *out_type, size_t out_type_size) {
+    cJSON *msg = cJSON_Parse(json_input);
+    if (msg == NULL) {
+        return 0;
+    }
+
+    cJSON *type = cJSON_GetObjectItem(msg, "type");
+    if (type == NULL || !cJSON_IsString(type)) {
+        cJSON_Delete(msg);
+        return 0;
+    }
+
+    // Copy type string into output buffer with safety checks.
+    strncpy(out_type, type->valuestring, out_type_size - 1);
+    out_type[out_type_size - 1] = '\0'; // Manually null-terminate to ensure safety.
+    cJSON_Delete(msg);
+    return 1;
+}
+
+/// @brief Performs compatibility handshake and returns 1 on success.
+/// @param sock_fd The file descriptor for the coordinator socket.
+/// @param buffer Reusable receive buffer.
+/// @return 1 if handshake accepted, 0 otherwise.
+static int perform_handshake(int sock_fd, char *buffer) {
+    char type_buffer[64];
+
+    send_handshake_message(sock_fd);
+    int bytes = receive_into_buffer(sock_fd, buffer);
+    if (bytes <= 0) {
+        return 0;
+    }
+
+    if (!parse_response_type(buffer, type_buffer, sizeof(type_buffer))) {
+        return 0;
+    }
+
+    // Handshake is successful if coordinator responds with handshake_ack.
+    // Any other response (including handshake_reject) is a failure.
+    if (strcmp(type_buffer, MSG_TYPE_HANDSHAKE_ACK) != 0) {
+        printf("Handshake failed: %s\n", buffer);
+        return 0;
+    }
+
+    printf("Handshake accepted by coordinator\n");
+    return 1;
 }
 
 /// @brief Registers the worker with the coordinator.
@@ -131,8 +206,14 @@ int main() {
 
     // connect() == worker dials coordinator
     connect_to_coordinator(sock_fd);
-
     printf("Connected to coordinator\n");
+
+    // Perform handshake to verify compatibility with coordinator before proceeding.
+    if (!perform_handshake(sock_fd, buffer)) {
+        printf("Unable to join compilation network\n");
+        close(sock_fd);
+        return 1;
+    }
 
     // Register with the coordinator, request a task, and start sending heartbeats in a loop.
     register_with_coordinator(sock_fd, buffer);


### PR DESCRIPTION
Adds functionality requiring that the coordinator and worker have a match of the following:
   - Architecture
   - Compiler version
   - Operating system
   - RPC protocol version